### PR TITLE
Add IP validation; add custom Author and Comment; add more de-ack conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[TOC]
-
 pd-nag-connector
 ================
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Contributors
 * David Nguyen (d_k_nguyen@yahoo.com, http://github.com/deeno35)
   * Icinga support ([PR #1](https://github.com/jeffwalter/pd-nag-connector/pull/1))
   * Icinga ACK timeout support ([PR #2](https://github.com/jeffwalter/pd-nag-connector/pull/2))
+* Stefan Wuensch (https://github.com/stefan-wuensch)
+  * Validate incoming connection with DNS lookup
+  * Dynamic Ack `Author` and `Comment` with links to person and incident in PD
+  * De-Ack also on change of assignment, or escalation
 
 Copyright and License
 ---------------------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[TOC]
+
 pd-nag-connector
 ================
 


### PR DESCRIPTION
1. Look up `webhooks.pagerduty.com` in DNS and make sure incoming IP is one of those (https://support.pagerduty.com/hc/en-us/articles/204923760)
2. Generate dynamic Author and Comment for the Ack in Nagios, with data from PagerDuty - including links to the person and the incident in PD
3. Add Assign and Escalate as other PD events which will trigger a de-Ack in Nagios. (If the incident is re-assigned or escalated, the previous Nagios Ack isn't relevant any longer.)
